### PR TITLE
Dictionaries

### DIFF
--- a/gibbon-compiler/examples/test08e_dictfoo.gib
+++ b/gibbon-compiler/examples/test08e_dictfoo.gib
@@ -1,0 +1,7 @@
+#lang gibbon
+
+(data Foo (MkFoo Int))
+
+(let ([d : (SymDict Foo) (ann (empty-dict) (SymDict Foo))])
+  (let ([d2 : (SymDict Foo) (insert d (quote x) (ann (MkFoo 5) Foo))])
+    (ann (lookup d2 (quote x)) Foo)))

--- a/gibbon-compiler/examples/test08e_dictfoo.gib
+++ b/gibbon-compiler/examples/test08e_dictfoo.gib
@@ -4,4 +4,5 @@
 
 (let ([d : (SymDict Foo) (ann (empty-dict) (SymDict Foo))])
   (let ([d2 : (SymDict Foo) (insert d (quote x) (ann (MkFoo 5) Foo))])
-    (ann (lookup d2 (quote x)) Foo)))
+    (case (ann (lookup d2 (quote x)) Foo)
+      [(MkFoo x) x])))

--- a/gibbon-compiler/examples/test08f_sharedict.gib
+++ b/gibbon-compiler/examples/test08f_sharedict.gib
@@ -1,0 +1,7 @@
+#lang gibbon
+
+(let ([d : (SymDict Sym) (ann (empty-dict) (SymDict Sym))])
+  (let ([d2 : (SymDict Sym) (insert d (quote x) (ann (quote a) Sym))])
+    (let ([d3 : (SymDict Sym) (insert d2 (quote y) (ann (quote b) Sym))])
+      (let ([d4 : (SymDict Sym) (insert d2 (quote y) (ann (quote c) Sym))])
+        (ann (lookup d4 (quote y)) Sym)))))

--- a/gibbon-compiler/rts.c
+++ b/gibbon-compiler/rts.c
@@ -187,6 +187,26 @@ IntTy dict_lookup_int(dict_item_t *ptr, SymTy key) {
   exit(1);
 }
 
+dict_item_t *dict_insert_ptr(dict_item_t *ptr, SymTy key, void* val) {
+  dict_item_t *ret = dict_alloc();
+  ret->key = key;
+  ret->ptrval = val;
+  ret->next = ptr;
+  return ret;
+}
+
+void* dict_lookup_ptr(dict_item_t *ptr, SymTy key) {
+  while (ptr != 0) {
+    if (ptr->key == key) {
+      return ptr->ptrval;
+    } else {
+      ptr = ptr->next;
+    }
+  }
+  printf("Error, key %lld not found!\n",key);
+  exit(1);
+}
+
 char* read_benchfile_param() {
   if (global_benchfile_param == NULL) {
     fprintf(stderr, "read_benchfile_param: benchmark input file was not set!\n");
@@ -267,6 +287,10 @@ int main(int argc, char** argv)
       fprintf(stderr, " [gibbon rts] failed to getrlimit, code %d\n", code);
       abort();
     }
+
+    #ifdef GCALLOC
+    GC_INIT();
+    #endif
     
     // lim.rlim_cur = 1024LU * 1024LU * 1024LU; // 1GB stack.
     lim.rlim_cur = 512LU * 1024LU * 1024LU; // 500MB stack.

--- a/gibbon-compiler/rts.c
+++ b/gibbon-compiler/rts.c
@@ -12,6 +12,9 @@
 #include <fcntl.h>
 #include <stdarg.h> // For va_start etc
 #include <errno.h>
+#ifdef GCALLOC
+#include "gc.h" // Try to use conservative gc
+#endif
 
 // Big default.  Used for --packed and --pointer/bumpalloc
 // static long long global_default_buf_size = (500lu * 1000lu * 1000lu);
@@ -118,11 +121,29 @@ static const int num_workers = 1;
   void save_alloc_state() {}
   void restore_alloc_state() {}
 
-  #define ALLOC(n) malloc(n)
+  #ifdef GCALLOC
+
+    #define ALLOC(n) GC_MALLOC(n)
+
+  #else
+
+    #define ALLOC(n) malloc(n)
+
+  #endif // GCALLOC
 
 #endif // BUMPALLOC
 
 #define ALLOC_PACKED(n) ALLOC(n)
+
+#ifdef GCALLOC
+
+  #define ATOM_ALLOC(n) GC_MALLOC_ATOMIC(n)
+
+#else
+
+  #define ATOM_ALLOC(n) ALLOC(n)
+
+#endif // GCALLOC
 
 // --------------------------------------------------------------------------------
 

--- a/gibbon-compiler/src/Packed/FirstOrder/Passes/Codegen.hs
+++ b/gibbon-compiler/src/Packed/FirstOrder/Passes/Codegen.hs
@@ -107,20 +107,18 @@ codegenProg isPacked prg@(Prog funs mtal) = do
       let rtsPath = case lookup "TREELANGDIR" env of
                       Just p -> p ++"/gibbon-compiler/rts.c"
                       Nothing -> "rts.c" -- Assume we're running from the compiler dir!
-      e <- doesFileExist rtsPath
-      unless e $ error$ "codegen: rts.c file not found at path: "++rtsPath
-                       ++"\n Consider setting TREELANGDIR to repo root.\n"
-      rts <- readFile rtsPath -- TODO (maybe): We can read this in in compile time using TH
-      return (rts ++ '\n' : pretty 80 (stack (map ppr defs)))
-    where
+      let imp = "#include \"" ++ rtsPath ++ "\"" -- include rts via CPP
+          bod = pretty 80 $ stack $ map ppr defs
+      return $ imp ++ '\n' : bod
+    where 
       defs = fst $ runSyM 0 $ do
         funs' <- mapM codegenFun funs
         prots <- mapM makeProt funs
-        main_expr' <- main_expr
-        return (makeStructs (S.toList $ harvestStructTys prg) ++ prots ++ funs' ++ [main_expr'])
+        mainExpr' <- mainExpr
+        return $ makeStructs (S.toList $ harvestStructTys prg) ++ prots ++ funs' ++ [mainExpr']
 
-      main_expr :: SyM C.Definition
-      main_expr =
+      mainExpr :: SyM C.Definition
+      mainExpr =
         case mtal of
           Just (PrintExp t) -> do
             t' <- runReaderT (codegenTail t (codegenTy IntTy)) isPacked

--- a/gibbon-compiler/src/Packed/FirstOrder/Passes/Cursorize.hs
+++ b/gibbon-compiler/src/Packed/FirstOrder/Passes/Cursorize.hs
@@ -705,6 +705,14 @@ cursorDirect prg0@L2.Prog{ddefs,fundefs,mainExp} = do
         do Right e <- doapp [] tenv isMain (Just destC) v e
            return e
 
+      -- Dict operations... AUDITME: should we route cursors to and from dict ops?
+      PrimAppE (L1.DictInsertP t) [d,v] -> do d' <- go tenv d
+                                              v' <- exp tenv isMain v
+                                              return $ Di $ PrimAppE (L1.DictInsertP t) [fromDi d',v']
+      PrimAppE (L1.DictLookupP t) [d,k] -> do d' <- go tenv d
+                                              k' <- exp tenv isMain k
+                                              return $ Di $ PrimAppE (L1.DictInsertP t) [fromDi d',k']
+                                          
       -- This should not be possible for prims that do not return PackedTy data.
       PrimAppE _ _ -> error$ "cursorDirect: unexpected PrimAppE in packed context: "++sdoc ex0
 

--- a/gibbon-compiler/src/Packed/FirstOrder/Passes/Cursorize.hs
+++ b/gibbon-compiler/src/Packed/FirstOrder/Passes/Cursorize.hs
@@ -254,15 +254,26 @@ cursorDirect prg0@L2.Prog{ddefs,fundefs,mainExp} = do
         (LetE (vr, CursorTy (), PrimAppE (L1.ReadPackedFile path tyc (typ ty2)) [])) <$>
           exp (M.insert vr (CursorTy ()) tenv) isMain bod
 
-      LetE (vr, _ty, PrimAppE (L1.DictLookupP (PackedTy _da _a)) args) bod ->
-        (LetE (vr, CursorTy (), PrimAppE (L1.DictLookupP (CursorTy ())) args)) <$>
-          exp (M.insert vr (CursorTy ()) tenv) isMain bod
-      LetE (vr, _ty, PrimAppE (L1.DictInsertP (PackedTy _da _a)) args) bod ->
-        (LetE (vr, SymDictTy (CursorTy ()), PrimAppE (L1.DictInsertP (CursorTy ())) args)) <$>
-          exp tenv isMain bod
+      -- LetE (vr, _ty, PrimAppE (L1.DictLookupP (PackedTy _da _a)) args) bod ->
+      --   (LetE (vr, CursorTy (), PrimAppE (L1.DictLookupP (CursorTy ())) args)) <$>
+      --     exp (M.insert vr (CursorTy ()) tenv) isMain bod
+      -- LetE (vr, _ty, PrimAppE (L1.DictInsertP (PackedTy _da _a)) args) bod ->
+      --   (LetE (vr, SymDictTy (CursorTy ()), PrimAppE (L1.DictInsertP (CursorTy ())) args)) <$>
+      --     exp tenv isMain bod
       LetE (vr, _ty, PrimAppE (L1.DictEmptyP (PackedTy _da _a)) args) bod ->
         (LetE (vr, SymDictTy (CursorTy ()), PrimAppE (L1.DictEmptyP (CursorTy ())) args)) <$>
           exp tenv isMain bod
+      -- PrimAppE (L1.DictLookupP (PackedTy _da a)) [d,k] -> 
+      --     do -- d' <- go tenv d
+      --        k' <- exp tenv isMain k
+      --        return $ PrimAppE (L1.DictLookupP (PackedTy "CURSOR_TY" a)) [(ProjE 1 d),k']
+      -- LetE (vr, _ty, PrimAppE (L1.DictLookupP (PackedTy _da _a)) [d,k]) bod ->
+      --     do vr' <- gensym (toVar "tmpdict")
+      --        (\x -> (LetE (vr', CursorTy (), PrimAppE (L1.DictLookupP (PackedTy _da _a)) [(ProjE 1 d),k])
+      --                     (LetE (vr, ProdTy [CursorTy (), CursorTy ()],
+      --                              MkProdE [(ProjE 0 d), (VarE vr')]) x))) <$>
+      --             exp (M.insert vr' (CursorTy ()) (M.insert vr (ProdTy [CursorTy (), CursorTy ()]) tenv)) isMain bod 
+          
 
 
       -- If we're not returning a packed type in the current
@@ -651,6 +662,26 @@ cursorDirect prg0@L2.Prog{ddefs,fundefs,mainExp} = do
           return $ Di (MkProdE [ PrimAppE (L1.ReadPackedFile path tyc (typ t2)) []
                                , PrimAppE L1.MkNullCursor [] ])
 
+      LetE (vr, _ty, PrimAppE (L1.DictEmptyP (PackedTy _da _a)) []) bod ->
+        onDi (LetE (vr, SymDictTy (CursorTy ()), PrimAppE (L1.DictEmptyP (CursorTy ())) [])) <$>
+          go (M.insert vr (SymDictTy (CursorTy ())) tenv) bod
+      LetE (vr, _ty, PrimAppE (L1.DictInsertP (PackedTy _da _a)) [d,k,v]) bod ->
+          do v' <- go tenv v
+             vr' <- gensym (toVar "tmpdict")
+             onDi (\x -> (LetE (vr', ProdTy [CursorTy (), CursorTy ()], fromDi v')
+                               (LetE (vr, ProdTy [CursorTy (), SymDictTy (CursorTy ())],
+                                        MkProdE [(ProjE 1 (VarE vr')),
+                                                 PrimAppE (L1.DictInsertP (CursorTy ())) [d,k,ProjE 0 (VarE vr')]]) x))) <$>
+                  go (M.insert vr' (ProdTy [CursorTy (), CursorTy ()])
+                           (M.insert vr (ProdTy [CursorTy (), (SymDictTy (CursorTy ()))]) tenv)) bod
+      LetE (vr, _ty, PrimAppE (L1.DictLookupP (PackedTy _da _a)) [d,k]) bod ->
+          do vr' <- gensym (toVar "tmpdict")
+             onDi (\x -> (LetE (vr', CursorTy (), PrimAppE (L1.DictLookupP (PackedTy _da _a)) [(ProjE 1 d),k])
+                          (LetE (vr, ProdTy [CursorTy (), CursorTy ()],
+                                   MkProdE [(ProjE 0 d), (VarE vr')]) x))) <$>
+                  go (M.insert vr' (CursorTy ()) (M.insert vr (ProdTy [CursorTy (), CursorTy ()]) tenv)) bod 
+                                                     
+
       -- The only primitive that returns packed data is ReadPackedFile:
       -- This is simpler than TimeIt below.  While it's out-of-line,
       -- it doesn't need memory allocation (NewBuffer/ScopedBuffer).
@@ -702,6 +733,10 @@ cursorDirect prg0@L2.Prog{ddefs,fundefs,mainExp} = do
 
       LetE (v,ty, PrimAppE p ls) bod
 --         | L1.ReadPackedFile _ _ <- p -> ((v,ty,) <$> go tenv (PrimAppE p ls))
+        -- | L1.DictEmptyP (PackedTy _da _a) <- p -> onDi (LetE (v,SymDictTy (CursorTy ()), PrimAppE (L1.DictEmptyP (CursorTy ())) [])) <$>
+        --                                      go (M.insert v (SymDictTy (CursorTy ())) tenv) bod
+        -- | L1.DictInsertP (PackedTy _da _a) <- p -> onDi (LetE (v,SymDictTy (CursorTy ()), PrimAppE (L1.DictInsertP (CursorTy ())) ls)) <$>
+        --                                       go (M.insert v (SymDictTy (CursorTy ())) tenv) bod 
         | otherwise -> onDi (LetE (v,typ ty,PrimAppE p ls)) <$> go (M.insert v ty tenv) bod
 
       -- LetE (v1,t1, LetE (v2,t2, rhs2) rhs1) bod ->
@@ -716,16 +751,9 @@ cursorDirect prg0@L2.Prog{ddefs,fundefs,mainExp} = do
         do Right e <- doapp [] tenv isMain (Just destC) v e
            return e
 
-      -- Dict operations... AUDITME: should we route cursors to and from dict ops?
-      PrimAppE (L1.DictInsertP (PackedTy _da a)) [d,k,v] ->
-          do -- d' <- go tenv d
-             v' <- exp tenv isMain v
-             k' <- exp tenv isMain k
-             return $ Di $ PrimAppE (L1.DictInsertP (PackedTy "CURSOR_TY" a)) [d,k',v']
-      PrimAppE (L1.DictLookupP (PackedTy _da a)) [d,k] -> 
-          do -- d' <- go tenv d
-             k' <- exp tenv isMain k
-             return $ Di $ PrimAppE (L1.DictLookupP (PackedTy "CURSOR_TY" a)) [d,k']
+      PrimAppE (L1.DictLookupP (PackedTy _da _a)) [d,k] -> 
+          do k' <- exp tenv isMain k
+             return $ Di $ PrimAppE (L1.DictLookupP (CursorTy ())) [(ProjE 1 d),k']
 
       -- This should not be possible for prims that do not return PackedTy data.
       PrimAppE _ _ -> error$ "cursorDirect: unexpected PrimAppE in packed context: "++sdoc ex0

--- a/gibbon-compiler/src/Packed/FirstOrder/Passes/Cursorize.hs
+++ b/gibbon-compiler/src/Packed/FirstOrder/Passes/Cursorize.hs
@@ -705,14 +705,6 @@ cursorDirect prg0@L2.Prog{ddefs,fundefs,mainExp} = do
         do Right e <- doapp [] tenv isMain (Just destC) v e
            return e
 
-      -- Dict operations... AUDITME: should we route cursors to and from dict ops?
-      PrimAppE (L1.DictInsertP t) [d,v] -> do d' <- go tenv d
-                                              v' <- exp tenv isMain v
-                                              return $ Di $ PrimAppE (L1.DictInsertP t) [fromDi d',v']
-      PrimAppE (L1.DictLookupP t) [d,k] -> do d' <- go tenv d
-                                              k' <- exp tenv isMain k
-                                              return $ Di $ PrimAppE (L1.DictInsertP t) [fromDi d',k']
-                                          
       -- This should not be possible for prims that do not return PackedTy data.
       PrimAppE _ _ -> error$ "cursorDirect: unexpected PrimAppE in packed context: "++sdoc ex0
 

--- a/gibbon-compiler/src/Packed/FirstOrder/Passes/InlinePacked.hs
+++ b/gibbon-compiler/src/Packed/FirstOrder/Passes/InlinePacked.hs
@@ -103,10 +103,14 @@ inlinePackedExp ddefs = exp True
        -- DONT inline file reading:
        | PrimAppE (L1.ReadPackedFile{}) _ <- rhs ->
           LetE (var v,t, rhs') (exp strong ((v,(t,Nothing)):env) bod)
-       -- Skip inlining empty dictionary creation
+       -- Skip inlining dictionary operations... AUDITME: is this okay? 
        | PrimAppE (L1.DictEmptyP{}) _ <- rhs ->
           LetE (var v,t,rhs') (exp strong ((v,(t,Nothing)):env) bod)
-       -- TODO: handle other dictionary operations
+       | PrimAppE (L1.DictInsertP{}) _ <- rhs ->
+          LetE (var v,t,rhs') (exp strong ((v,(t,Nothing)):env) bod)
+       | PrimAppE (L1.DictLookupP{}) _ <- rhs ->
+          LetE (var v,t,rhs') (exp strong ((v,(t,Nothing)):env) bod)
+
 
 --      | L1.hasTimeIt rhs  -> __ -- AUDITME: is this still needed?
        | isConstructor rhs -> addAndGo

--- a/gibbon-compiler/src/Packed/FirstOrder/Passes/InlinePacked.hs
+++ b/gibbon-compiler/src/Packed/FirstOrder/Passes/InlinePacked.hs
@@ -103,6 +103,10 @@ inlinePackedExp ddefs = exp True
        -- DONT inline file reading:
        | PrimAppE (L1.ReadPackedFile{}) _ <- rhs ->
           LetE (var v,t, rhs') (exp strong ((v,(t,Nothing)):env) bod)
+       -- Skip inlining empty dictionary creation
+       | PrimAppE (L1.DictEmptyP{}) _ <- rhs ->
+          LetE (var v,t,rhs') (exp strong ((v,(t,Nothing)):env) bod)
+       -- TODO: handle other dictionary operations
 
 --      | L1.hasTimeIt rhs  -> __ -- AUDITME: is this still needed?
        | isConstructor rhs -> addAndGo


### PR DESCRIPTION
Improving support for dictionaries in Gibbon, from #10.

### Tasks

- [x] Extend sexp parser with dictionary operations
- [x] Add simple rts hooks for creating, updating, and querying dictionaries
- [x] Add typed dictionary ops to IR
- [x] Full compiler support for dictionaries of fixed width types (ints, syms, etc)
- [ ] Full compiler support for dictionaries of packed type
  - [x] Add cases to `cursorize` for packed dictionary types
  - [ ] Generate working code
- [ ] Add/implement fancy data structure for persistent dictionaries 
  - [x] Implement simple a-list structure
  - [ ] Switch to HAMT (hopefully find a portable C library)
- [x] Add option to turn on conservative garbage collector in rts
