### PR TITLE
add sample quoter for Gibbon

### DIFF
--- a/gibbon-compiler/gibbon.cabal
+++ b/gibbon-compiler/gibbon.cabal
@@ -78,6 +78,10 @@ library
                        Gibbon.Passes.RearrangeFree
                        Gibbon.Passes.Codegen
 
+                       -- template haskell
+                       Gibbon.TH
+                       Gibbon.THExample
+
   other-extensions:    DeriveDataTypeable CPP
 
   build-depends:       base                     >= 4.9       &&  < 4.13
@@ -106,6 +110,8 @@ library
                      , GenericPretty            >= 1.2.1     &&  < 1.3
                      , language-c-quote         >= 0.12.1    &&  < 0.13
                      , mainland-pretty          >= 0.6.1     &&  < 0.8
+                     -- Template Haskell:
+                     , template-haskell >= 2.14 && <2.15
 -- Brings in lots of ekmett dependencies:
 --                     , either
 

--- a/gibbon-compiler/src/Gibbon/Compiler.hs
+++ b/gibbon-compiler/src/Gibbon/Compiler.hs
@@ -9,10 +9,10 @@ module Gibbon.Compiler
     ( -- * Compiler entrypoints
       compile, compileCmd
       -- * Configuration options and parsing
-     , Config (..), Mode(..), Input(..)
+     , Config (..), Mode(..), Input(..), CompileState (..)
      , configParser, configWithArgs, defaultConfig
       -- * Some other helper fns
-     , compileAndRunExe
+     , compileAndRunExe, passes
     )
   where
 

--- a/gibbon-compiler/src/Gibbon/HaskellFrontend.hs
+++ b/gibbon-compiler/src/Gibbon/HaskellFrontend.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 module Gibbon.HaskellFrontend
-  ( parseFile, primMap, multiArgsToOne ) where
+  ( parseFile, primMap, multiArgsToOne, desugarModule ) where
 
 import           Data.Foldable ( foldrM )
 import           Data.Maybe (catMaybes)

--- a/gibbon-compiler/src/Gibbon/TH.hs
+++ b/gibbon-compiler/src/Gibbon/TH.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Gibbon.TH where
+
+import           Language.Haskell.TH     hiding ( ScopedTypeVariables )
+import           Language.Haskell.TH.Quote
+import           Control.Monad.State.Strict
+import           Data.Set
+import           Language.Haskell.Exts.Extension
+import           Language.Haskell.Exts.Parser
+import           Gibbon.HaskellFrontend
+import           Gibbon.Common
+import           Gibbon.Compiler
+import           Gibbon.DynFlags
+import           Gibbon.Passes.Freshen
+import           Gibbon.Passes.Codegen
+import qualified Gibbon.L0.Syntax              as L0
+import qualified Gibbon.L0.Typecheck           as L0
+import qualified Gibbon.L0.Specialize2         as L0
+import qualified Gibbon.L1.Syntax              as L1
+import           System.IO.Unsafe
+
+gQuoter :: QuasiQuoter
+gQuoter = QuasiQuoter compileL1 undefined undefined undefined
+
+-- | same as Frontend's parseFile and parseInput function, but not in IO
+parseL1 :: String -> (L1.Prog1, Int)
+parseL1 code =
+  let parse_mode = defaultParseMode
+        { extensions = [EnableExtension ScopedTypeVariables]
+                         ++ (extensions defaultParseMode)
+        }
+  in  case parseModuleWithMode parse_mode code of
+        ParseOk hs ->
+          runPassM defaultConfig 0 . mono_and_spec . desugarModule $ hs
+        ParseFailed _ e -> error ("haskell-src-exts failed: " ++ e)
+ where
+  mono_and_spec :: PassM L0.Prog0 -> PassM L1.Prog1
+  mono_and_spec pm_l0 = do
+    l00 <- pm_l0
+    l01 <- freshNames l00
+    l02 <- L0.tcProg l01
+    l1  <- L0.l0ToL1 l02
+    pure l1
+
+compileL1 :: String -> Q Exp
+compileL1 fp1 =
+  let (l1, _) = parseL1 fp1
+      config' = Config Haskell
+                       ToC
+                       Nothing
+                       Nothing
+                       0
+                       "gcc"
+                       ""
+                       Nothing
+                       Nothing
+                       C
+                       (DynFlags empty empty)
+                       Nothing
+      stM = passes config' l1
+      l4  = evalStateT stM (CompileState { cnt = 0, result = Nothing })
+      str = (codegenProg config') =<< l4
+  in  return . LitE . StringL . unsafePerformIO $ str

--- a/gibbon-compiler/src/Gibbon/THExample.hs
+++ b/gibbon-compiler/src/Gibbon/THExample.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Gibbon.THExample where
+
+import           Gibbon.TH
+
+example :: String
+example = [gQuoter|
+data Tree = Leaf Int | Node Tree Tree
+
+add1 :: Tree -> Tree
+add1 t = case t of
+           Leaf x     -> Leaf (x + 1)
+           Node x1 x2 -> Node (add1 x1) (add1 x2)
+
+main :: Tree
+main = add1 (Node (Leaf 1) (Leaf 2))|]


### PR DESCRIPTION
Gibbon.TH exports a `gQuoter`. Quoting `L1` programs using this quoter will emit Gibbon compiled C code.

Usage can be seen under Gibbon.THExample