### PR TITLE
Fixing testcases

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,18 @@ Gibbon is implemented in Haskell, and is set up to be built with
 [Cabal](https://cabal.readthedocs.io/en/3.4/).
 After you install Cabal, proceed to installing Gibbon's dependencies:
 
-- Ubuntu:
+- Ubuntu (works on 18.04, fails on 20.04<sup><a name="footnote1">1</a></sup>]):
 
 ```
- $ sudo apt-get install libgc-dev libgmp-dev gcc-7 uthash-dev software-properties-common haskell-stack
+ $ sudo apt-get install libgc-dev libgmp-dev gcc-7 uthash-dev software-properties-common
  $ sudo add-apt-repository ppa:plt/racket && sudo apt update && sudo apt install racket
  $ sudo add-apt-repository ppa:hvr/ghc && sudo apt update && sudo apt install ghc-9.0.1 cabal-install-3.4
 ```
+- Add `/opt/ghc/bin` to path for `cabal` and `ghc` to work.
+- Install haskell stack using steps at `https://docs.haskellstack.org/en/stable/install_and_upgrade/` (works with stack `2.7.3`, the version in `18.04`, i.e. stack `1.5.1-1` gives `AesonException "Error in $['system-info']: key \"os\" not present"`)
+- Make gcc-7.5 the default gcc with `sudo ln -sf /usr/bin/gcc-7 /usr/bin/gcc`
+
+<sup>[1](#footnote1)</sup>  Header files `cilk/cilk.h` and `cilk/cilk_api.h` are not present in `libgcc-7-dev` which comes with `20.04`
 
 
 - OSX:
@@ -65,7 +70,6 @@ At this point you can run the Gibbon executable:
 If you'd like to run the testsuite, you can do so with:
 
     $ cd $GIBBONDIR && ./run_all_tests.sh
-
 
 ## Using Gibbon
 

--- a/gibbon-compiler/stack.yaml
+++ b/gibbon-compiler/stack.yaml
@@ -5,6 +5,7 @@ packages:
 
 extra-deps:
 - s-cargot-0.1.4.0
+- hse-cpp-0.2
 
 flags: {}
 extra-package-dbs: []

--- a/gibbon-stdlib/Gibbon/Vector.hs
+++ b/gibbon-stdlib/Gibbon/Vector.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-#if __GLASGOW_HASKELL__ >= 901
+#if __GLASGOW_HASKELL__ >= 900
 {-# LANGUAGE LinearTypes         #-}
 #endif
 


### PR DESCRIPTION
fixes #138 
- For `ghc-9.0.1` the `__GLASGOW_HASKELL__` value is `900`
- `lts-14.20` was failing for gibbon-compiler so added extra dep.
- `cilk/cilk.h` and `cilk/cilk_plus.h` are missing from `focal` ubuntu but there in `bionic`. Also the `haskell-stack` in bionic doesn't work so we need to install using official source. Also added instructions to set `gcc-7.5` as the default gcc and add `cabal` and `ghc` to path.