### PR TITLE
Update Codegen.hs:codegenProg haddocks

### DIFF
--- a/gibbon-compiler/src/Gibbon/Passes/Codegen.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/Codegen.hs
@@ -184,10 +184,8 @@ sortFns (Prog _ _ funs mtal) = foldl go S.empty allTails
 --------------------------------------------------------------------------------
 -- * C codegen
 
--- | Compile a program to C code which has the side effect of the
--- "main" expression in that program.
---
---  The boolean flag is true when we are compiling in "Packed" mode.
+-- | Compile a program to C code that has the side effect of the
+-- "gibbon_main" expression in that program.
 codegenProg :: Config -> Prog -> IO String
 codegenProg cfg prg@(Prog info_tbl sym_tbl funs mtal) =
       return (hashIncludes ++ pretty 80 (stack (map ppr defs)))


### PR DESCRIPTION
- There was no "Bool" flag since 5  years ago (7c2f10f4e0bed9731c89df8941c95a9fc39a3c9e)

- the main expression is called "gibbon_main" these days

[skip ci]