### PR TITLE
cabal.project: restrict tabs

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,4 @@
 packages: gibbon-compiler
+
+program-options
+    ghc-options: -Werror=tabs


### PR DESCRIPTION
I plan to cleanup all warnings and turn on `-Werror` but restricting tabs is a first step.