### PR TITLE
Fix includes in RTS

### DIFF
--- a/gibbon-rts/rts-c/gibbon_rts.h
+++ b/gibbon-rts/rts-c/gibbon_rts.h
@@ -10,6 +10,11 @@
 #include <limits.h>
 #include <time.h>
 
+#ifdef _GIBBON_PARALLEL
+#include <cilk/cilk.h>
+#include <cilk/cilk_api.h>
+#endif
+
 /*
  * CPP macros used in the RTS:
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
so that we don't get "implicit function declaration" for cilk stuff, e.g.: https://github.com/iu-parfunc/gibbon/pull/247#issuecomment-2161391004