### PR TITLE
Switch from `symbol` to `intern` as the former seems dormant

### DIFF
--- a/gibbon-compiler/gibbon.cabal
+++ b/gibbon-compiler/gibbon.cabal
@@ -115,7 +115,7 @@ library
                      , hse-cpp                  >= 0.1       &&  < 1
                      , s-cargot                 >= 0.1.3     &&  < 1
                      , srcloc                   >= 0.6       &&  < 1
-                     , symbol                   >= 0.2.4     &&  < 1
+                     , intern                   ^>= 0.9
                      -- Pretty printers:
                      , pretty                   >= 1.1.1.3   &&  < 1.2
                      , GenericPretty            >= 1.2.1     &&  < 2

--- a/gibbon-compiler/src/Gibbon/Common.hs
+++ b/gibbon-compiler/src/Gibbon/Common.hs
@@ -10,6 +10,7 @@ module Gibbon.Common
          -- * Variables
          Var(..), LocVar, RegVar, fromVar, toVar, varAppend, toEndV, toSeqV, cleanFunName
        , TyVar(..), isUserTv
+       , Symbol, intern, unintern
 
          -- * Gensym monad
        , SyM, gensym, gensym_tag, genLetter, newUniq, runSyM
@@ -49,7 +50,8 @@ import Data.Char
 import qualified Data.List as L
 import Data.Map as M
 import Data.String
-import Data.Symbol
+import qualified Data.Interned as DI
+import Data.Interned.String
 import Data.Word
 import GHC.Generics
 import GHC.Stack (HasCallStack)
@@ -66,6 +68,24 @@ import Language.C.Quote.CUDA (ToIdent, toIdent)
 import Gibbon.DynFlags
 
 --------------------------------------------------------------------------------
+
+newtype Symbol = Symbol InternedString
+  deriving (Eq, Ord)
+
+instance Show Symbol where
+    showsPrec d s = showsPrec d (unintern s)
+
+instance Read Symbol where
+    readsPrec _d t = [(intern s, t') | (s, t') <- readList t]
+
+instance IsString Symbol where
+  fromString = intern
+
+intern :: String -> Symbol
+intern = Symbol . DI.intern
+
+unintern :: Symbol -> String
+unintern (Symbol is) = DI.unintern is
 
 -- type CursorVar = Var
 newtype Var = Var Symbol

--- a/gibbon-compiler/src/Gibbon/L0/ElimNewtype.hs
+++ b/gibbon-compiler/src/Gibbon/L0/ElimNewtype.hs
@@ -6,7 +6,6 @@ import Gibbon.Common
 import Control.Arrow
 import qualified Data.Map as M
 import qualified Data.Set as S
-import Data.Symbol ( unintern )
 
 elimNewtypes :: Monad m => Prog0 -> m Prog0
 elimNewtypes = pure . elimProgram

--- a/gibbon-compiler/src/Gibbon/L1/GenSML.hs
+++ b/gibbon-compiler/src/Gibbon/L1/GenSML.hs
@@ -9,7 +9,6 @@ import Control.Monad
 import Data.Map hiding (foldr, fold, null, empty)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
-import Data.Symbol
 
 import Data.Foldable hiding ( toList )
 import Data.Graph

--- a/gibbon-compiler/src/Gibbon/Passes/Fusion2.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/Fusion2.hs
@@ -11,7 +11,6 @@ import qualified Data.Map as M
 import qualified Data.List as L
 import qualified Data.Set as S
 import qualified Data.Vector as V
-import           Data.Symbol
 import           Data.Char ( toLower )
 import           Debug.Trace
 import           Control.DeepSeq


### PR DESCRIPTION
[`intern`](https://hackage.haskell.org/package/intern) seems to serve the same purpose as [`symbol`](https://hackage.haskell.org/package/symbol) but, unlike it, is actively maintained by Ryan G. Scott and is a part of kmettoverse.

The only kink is that it doesn't have a Read instance. I'm not sure why we need a Read instance anyway, but I had to define a trivial one otherwise it's a hassle to remove all `deriving Read` over the code. It'd be great to figure out if we really need it.

This hopefully unlocks support for GHC 9.10 (currently, `symbol` precludes it).