### PR TITLE
update stack resolver to a version compatible with our version of safe

### DIFF
--- a/gibbon-compiler/stack.yaml
+++ b/gibbon-compiler/stack.yaml
@@ -1,11 +1,11 @@
-resolver: lts-20.9
+resolver: lts-23.24
 
 packages:
 - '.'
 
 extra-deps:
   - hse-cpp-0.2
-  - s-cargot-0.1.4.0
+  - s-cargot-0.1.6.0
   - language-python-0.5.8
   - srcloc-0.6
 


### PR DESCRIPTION
It looks like we're mostly not using stack anymore, but the script run_all_tests.sh is still building with stack. Thanks to @Noir01 for running the script and finding it won't build with the resolver in stack.yaml. We should probably switch everything to cabal, but this gets the script running again.

(It looks like the CI runs are showing as cancelled on this commit)